### PR TITLE
Fixes issue #3

### DIFF
--- a/manifest/entrypoint.sh
+++ b/manifest/entrypoint.sh
@@ -13,32 +13,5 @@ fi
 procs=$(cat /proc/cpuinfo | grep processor | wc -l)
 sed -i -e "s/worker_processes 5/worker_processes $procs/" /etc/nginx/nginx.conf
 
-# Very dirty hack to replace variables in code with ENVIRONMENT values
-if [[ -v TEMPLATE_NGINX_HTML ]] ; then
-  for i in $(env)
-  do
-    variable=$(echo "$i" | cut -d'=' -f1)
-    value=$(echo "$i" | cut -d'=' -f2)
-    if [[ "$variable" != '%s' ]] ; then
-      replace='\$\$_'${variable}'_\$\$'
-      find /var/www/viewer -type f -exec sed -i -e 's#'${replace}'#'${value}'#g' {} \;
-    fi
-  done
-fi
-
-# Very dirty hack to replace variables in conf with ENVIRONMENT values
-if [[ -v TEMPLATE_PERL_CONF ]] ; then
-  for i in $(env)
-  do
-    variable=$(echo "$i" | cut -d'=' -f1)
-    value=$(echo "$i" | cut -d'=' -f2)
-    if [[ "$variable" != '%s' ]] ; then
-      replace='\$\$_'${variable}'_\$\$'
-      find /usr/bin -type f -name *.conf -exec sed -i -e 's#'${replace}'#'${value}'#g' {} \;
-    fi
-  done
-fi
-
 # Start supervisord and services
 /usr/bin/supervisord -n -c /etc/supervisord.conf
-

--- a/manifest/usr/bin/dmarcts-report-parser.conf
+++ b/manifest/usr/bin/dmarcts-report-parser.conf
@@ -8,34 +8,34 @@
 $debug = 0;
 $delete_reports = 0;
 
-$dbname = '$$_REPORT_DB_NAME_$$';
-$dbuser = '$$_REPORT_DB_USER_$$';
-$dbpass = '$$_REPORT_DB_PASS_$$';
-$dbhost = '$$_REPORT_DB_HOST_$$'; # Set the hostname if we can't connect to the local socket.
+$dbname = $ENV{'REPORT_DB_NAME'};
+$dbuser = $ENV{'REPORT_DB_USER'};
+$dbpass = $ENV{'REPORT_DB_PASS'};
+$dbhost = $ENV{'REPORT_DB_HOST'}; # Set the hostname if we can't connect to the local socket.
 
-$imapserver       = '$$_PARSER_IMAP_SERVER_WITH_PORT_$$';
-$imapuser         = '$$_PARSER_IMAP_USER_$$';
-$imappass         = '$$_PARSER_IMAP_PASS_$$';
-$imapssl          = '0';        # If set to 1, remember to change server port to 993 and disable imaptls.
-$imaptls          = '1';        # Enabled as the default and best-practice.
-$tlsverify        = '0';        # Enable verify server cert as the default and best-practice.
-$imapignoreerror  = 0;          # set it to 1 if you see an "ERROR: message_string() 
-                                # expected 119613 bytes but received 81873 you may 
-                                # need the IgnoreSizeErrors option" because of malfunction
-                                # imap server as MS Exchange 2007, ...
-$imapreadfolder   = '$$_PARSER_IMAP_READ_FOLDER_$$';
+$imapserver       = $ENV{'PARSER_IMAP_SERVER_WITH_PORT'};
+$imapuser         = $ENV{'PARSER_IMAP_USER'};
+$imappass         = $ENV{'PARSER_IMAP_PASS'};
+$imapssl          = $ENV{'PARSER_IMAP_SSL'} // '0';         # If set to 1, remember to change server port to 993 and disable imaptls.
+$imaptls          = $ENV{'PARSER_IMAP_TLS'} // '1';         # Enabled as the default and best-practice.
+$tlsverify        = $ENV{'PARSER_IMAP_VERIFY'} // '0';      # Enable verify server cert as the default and best-practice.
+$imapignoreerror  = 0;                                      # set it to 1 if you see an "ERROR: message_string()
+                                                            # expected 119613 bytes but received 81873 you may
+                                                            # need the IgnoreSizeErrors option" because of malfunction
+                                                            # imap server as MS Exchange 2007, ...
+$imapreadfolder   = $ENV{'PARSER_IMAP_READ_FOLDER'};
 
 # If $imapmovefolder is set, processed IMAP messages will be moved (overruled by
 # the --delete option!)
-$imapmovefolder = '$$_PARSER_IMAP_MOVE_FOLDER_$$';
+$imapmovefolder = $ENV{'PARSER_IMAP_MOVE_FOLDER'};
 
 # maximum size of XML files to store in database, long files can cause transaction aborts
 $maxsize_xml = 50000;
 # store XML as base64 encopded gzip in database (save space, harder usable)
 $compress_xml = 0;
 
-# if there was an error during file processing (message does not contain XML or ZIP parts, 
-# or a database error) the parser reports an error and does not delete the file, even if 
-# delete_reports is set (or --delete is given). Deletion can be enforced by delete_failed, 
+# if there was an error during file processing (message does not contain XML or ZIP parts,
+# or a database error) the parser reports an error and does not delete the file, even if
+# delete_reports is set (or --delete is given). Deletion can be enforced by delete_failed,
 # however not for database errors.
 $delete_failed = 0;

--- a/manifest/var/www/viewer/dmarcts-report-viewer-config.php
+++ b/manifest/var/www/viewer/dmarcts-report-viewer-config.php
@@ -4,10 +4,10 @@
 // ### configuration ##################################################
 // ####################################################################
 
-$dbhost='$$_REPORT_DB_HOST_$$';
-$dbname='$$_REPORT_DB_NAME_$$';
-$dbuser='$$_REPORT_DB_USER_$$';
-$dbpass='$$_REPORT_DB_PASS_$$';
+$dbhost=getenv('REPORT_DB_HOST');
+$dbname=getenv('REPORT_DB_NAME');
+$dbuser=getenv('REPORT_DB_USER');
+$dbpass=getenv('REPORT_DB_PASS');
 $dbport='3306';
 
 $cssfile="default.css";


### PR DESCRIPTION
Fix for issue #3:

Use php and perl to directly read from env.
Extends the configurability by using additional env variables using the former static values as defaults.

`$imapssl` can be set with `PARSER_IMAP_SSL` and defaults to `0`
`$imaptls` can be set with `PARSER_IMAP_TLS` and defaults to `1`
`$tlsverify` can be set with `PARSER_IMAP_VERIFY` and defaults to `0`
