### PR TITLE
Expose env vars for config to PHP-FPM

### DIFF
--- a/manifest/entrypoint.sh
+++ b/manifest/entrypoint.sh
@@ -13,5 +13,10 @@ fi
 procs=$(cat /proc/cpuinfo | grep processor | wc -l)
 sed -i -e "s/worker_processes 5/worker_processes $procs/" /etc/nginx/nginx.conf
 
+# Copy important env vars for PHP-FPM to access
+PHP_ENV_FILE="/usr/etc/php-fpm.d/${PHP_ENV_FILE:-env.conf}"
+echo '[www]' > "$PHP_ENV_FILE"
+env | grep -e 'REPORT_DB_HOST' -e 'REPORT_DB_NAME' -e 'REPORT_DB_USER' -e 'REPORT_DB_PASS' | sed "s/\(.*\)=\(.*\)/env[\1]='\2'/" >> "$PHP_ENV_FILE"
+
 # Start supervisord and services
 /usr/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
PHP-FPM sanities the env by default. We need to expose `REPORT_DB_HOST`, `REPORT_DB_NAME`, `REPORT_DB_USER`, and `REPORT_DB_PASS`.

This will create a file at `/usr/etc/php-fpm.d/env.conf`. By setting `PHP_ENV_FILE` in their environment, a user may change the file name. Changing the file parent directory is prohibited.