### PR TITLE
Environment Variable for PARSER_IMAP_IGNORE_ERROR

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ Use SSL instead of default TLS. Set both to 0 to turn off encryption. (not recom
 ```
 Ignore ERROR: message_string() issue experienced with Exchange Online.
 ```yaml
-	- "PARSER_IMAP_IGNORE_ERROR=1"
+    - "PARSER_IMAP_IGNORE_ERROR=1"
 ```

--- a/README.md
+++ b/README.md
@@ -76,4 +76,7 @@ Use SSL instead of default TLS. Set both to 0 to turn off encryption. (not recom
     - "PARSER_IMAP_SSL=1"
     - "PARSER_IMAP_TLS=0"
 ```
-
+Ignore ERROR: message_string() issue experienced with Exchange Online.
+```yaml
+	- "PARSER_IMAP_IGNORE_ERROR=1"
+```

--- a/manifest/usr/bin/dmarcts-report-parser.conf
+++ b/manifest/usr/bin/dmarcts-report-parser.conf
@@ -28,7 +28,7 @@ $imappass         = $ENV{'PARSER_IMAP_PASS'};
 $imapssl          = $ENV{'PARSER_IMAP_SSL'} // '0';         # If set to 1, remember to change server port to 993 and disable imaptls.
 $imaptls          = $ENV{'PARSER_IMAP_TLS'} // '1';         # Enabled as the default and best-practice.
 $tlsverify        = $ENV{'PARSER_IMAP_VERIFY'} // '0';      # Enable verify server cert as the default and best-practice.
-$imapignoreerror  = 0;                                      # set it to 1 if you see an "ERROR: message_string()
+$imapignoreerror  = $ENV{'PARSER_IMAP_IGNORE_ERROR'} // '0';# set it to 1 if you see an "ERROR: message_string()
                                                             # expected 119613 bytes but received 81873 you may
                                                             # need the IgnoreSizeErrors option" because of malfunction
                                                             # imap server as MS Exchange 2007, ...


### PR DESCRIPTION
Nice image, thanks for sharing!  I was getting the example error from the conf file comment so I added env variable so we can use docker-compose.yml to ignore errors.  This was experienced with Exchange Online in Microsoft 365.  This appears to have resolved the issue and dmarc reports were successfully retrieved and moved into the processed folder.  I hope I submitted this pull request correctly - first time 😄 