### PR TITLE
Add tzdata package to fix wrong system time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY ./manifest/ /
 
 RUN set -x \
       && apk update \
-      && apk add bash expat-dev mariadb-dev mariadb-client mariadb-connector-c openssl openssl-dev gzip wget perl-utils g++ make perl-dev \
+      && apk add bash expat-dev mariadb-dev mariadb-client mariadb-connector-c openssl openssl-dev gzip wget perl-utils g++ make perl-dev tzdata \
       && wget -4 -q --no-check-certificate -O parser.zip $REPORT_PARSER_SOURCE \
       && wget -4 -q --no-check-certificate -O viewer.zip $REPORT_VIEWER_SOURCE \
       && unzip parser.zip && cp -av dmarcts-report-parser-master/* /usr/bin/ && rm -vf parser.zip && rm -rvf dmarcts-report-parser-master \


### PR DESCRIPTION
Without the tzdata package, the TZ env var won't have effect on the system time within the container, what will lead to wrong timestamps in any logs.