### PR TITLE
Get and parse dmarc reports once at startup

### DIFF
--- a/manifest/entrypoint.sh
+++ b/manifest/entrypoint.sh
@@ -27,3 +27,13 @@ grep -e ^REPORT_DB_PORT "$PHP_ENV_FILE" || echo env[REPORT_DB_PORT] = 3306 >> "$
 
 # Start supervisord and services
 /usr/bin/supervisord -n -c /etc/supervisord.conf
+
+# Get and parse dmarc reports once at startup to avoid PHP errors with a new database
+if /usr/bin/dmarcts-report-parser.pl -i -d -r > /var/log/nginx/dmarc-reports.log 2>&1; then
+  echo 'INFO: Dmarc reports parsed successfully'
+else
+  echo 'CRIT: Dmarc reports could not be parsed. Check your IMAP and MYSQL Settings.'
+  echo -e "DEBUG: Parsing failed with the following output:\n"
+  cat /var/log/nginx/dmarc-reports.log
+  exit 1
+fi


### PR DESCRIPTION
Run the dmarc report parser script once at startup instead of waiting for the cron schedule to avoid PHP errors with a new database.
Also show additional information in the container logs if something failed there.

This should also fix issues #17 and #19 