### PR TITLE
Fix execution order in entrypoint.sh

### DIFF
--- a/manifest/entrypoint.sh
+++ b/manifest/entrypoint.sh
@@ -25,9 +25,6 @@ env | grep -e 'REPORT_DB_HOST' -e 'REPORT_DB_PORT' -e 'REPORT_DB_NAME' -e 'REPOR
 # compat from older image where variable was not existing
 grep -e ^REPORT_DB_PORT "$PHP_ENV_FILE" || echo env[REPORT_DB_PORT] = 3306 >> "$PHP_ENV_FILE"
 
-# Start supervisord and services
-/usr/bin/supervisord -n -c /etc/supervisord.conf
-
 # Get and parse dmarc reports once at startup to avoid PHP errors with a new database
 if /usr/bin/dmarcts-report-parser.pl -i -d -r > /var/log/nginx/dmarc-reports.log 2>&1; then
   echo 'INFO: Dmarc reports parsed successfully'
@@ -37,3 +34,6 @@ else
   cat /var/log/nginx/dmarc-reports.log
   exit 1
 fi
+
+# Start supervisord and services
+/usr/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
I just checked my changes in PR #22 and I made a mistake in my commit yesterday that makes my code changes in the `entrypoint.sh` unreachable because supervisord is running in foreground mode.
It should be right before the line to start supervisord like in this PR.
Sorry for that.