### PR TITLE
Including PARSER_XML_MAXSIZE env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,10 @@ Parser and Viewer support Postgres now too (default is mysql)
 ```yaml
 - "REPORT_DB_TYPE=pgsql"
 ```
+
+Increase the maximum size of the XML file. (default is `50000` bytes)  
+When the size exceeds the maximum, one could experience an error `Uncaught ValueError: DOMDocument::loadXML(): Argument #1 ($source) must not be empty`.
+
+```yaml
+- "PARSER_XML_MAXSIZE=500000"
+```


### PR DESCRIPTION
Including the `PARSER_XML_MAXSIZE` environment variable in the README.md file as this is already fixed in https://github.com/gutmensch/docker-dmarc-report/issues/31.